### PR TITLE
libdraw: GCC 10 compatibility

### DIFF
--- a/modules/libdraw/libdraw.c
+++ b/modules/libdraw/libdraw.c
@@ -48,7 +48,7 @@ uint32_t drawing_stipple = 0xFFFFFFFF;
 #define _inline inline
 #endif
 
-_inline void _HLine8_nostipple( uint8_t * ptr, uint32_t length )
+static _inline void _HLine8_nostipple( uint8_t * ptr, uint32_t length )
 {
     if ( pixel_alpha == 255 )
     {
@@ -64,7 +64,7 @@ _inline void _HLine8_nostipple( uint8_t * ptr, uint32_t length )
 
 /* --------------------------------------------------------------------------- */
 
-_inline void _HLine8_stipple( uint8_t * ptr, uint32_t length )
+static _inline void _HLine8_stipple( uint8_t * ptr, uint32_t length )
 {
     register int n;
 
@@ -88,7 +88,7 @@ _inline void _HLine8_stipple( uint8_t * ptr, uint32_t length )
 
 /* --------------------------------------------------------------------------- */
 
-_inline void _HLine16_nostipple( uint16_t * ptr, uint32_t length )
+static _inline void _HLine16_nostipple( uint16_t * ptr, uint32_t length )
 {
     register int n ;
 
@@ -104,7 +104,7 @@ _inline void _HLine16_nostipple( uint16_t * ptr, uint32_t length )
 
 /* --------------------------------------------------------------------------- */
 
-_inline void _HLine16_stipple( uint16_t * ptr, uint32_t length )
+static _inline void _HLine16_stipple( uint16_t * ptr, uint32_t length )
 {
     register int n ;
 
@@ -128,7 +128,7 @@ _inline void _HLine16_stipple( uint16_t * ptr, uint32_t length )
 
 /* --------------------------------------------------------------------------- */
 
-_inline void _HLine32_nostipple( uint32_t * ptr, uint32_t length )
+static _inline void _HLine32_nostipple( uint32_t * ptr, uint32_t length )
 {
     register int n ;
 
@@ -190,7 +190,7 @@ _inline void _HLine32_nostipple( uint32_t * ptr, uint32_t length )
 
 /* --------------------------------------------------------------------------- */
 
-_inline void _HLine32_stipple( uint32_t * ptr, uint32_t length )
+static _inline void _HLine32_stipple( uint32_t * ptr, uint32_t length )
 {
     register int n ;
 


### PR DESCRIPTION
The internal libdraw functions must have static linkage